### PR TITLE
docs: add bundlejs to Web Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Alternatives to ad-supported websites, software, and publications.
 ### Web Apps
 
 - [Cloverleaf](https://cloverleaf.app) - An open source app to replace your password manager without storing your passwords anywhere.
+- [bundlejs](https://bundle.js.org) - A quick and easy way to bundle, minify, and compress (gzip and brotli) your ts, js, jsx and npm projects all online, while returning the final bundle file size.
 
 ## Resources
 


### PR DESCRIPTION
`bundlejs` is a quick and easy way to bundle your projects, minify and see it's gzip size. It's an online tool similar to [bundlephobia](https://bundlephobia.com/), but bundle does all the bundling locally on you browser and can treeshake and bundle multiple packages (both commonjs and esm) together, all without having to install any npm packages and with typescript support.